### PR TITLE
fix: refactor construct_metadata to use schema-aligned keys (virtual-twin/tvbo#16)

### DIFF
--- a/tvb_ext_ontology/handlers.py
+++ b/tvb_ext_ontology/handlers.py
@@ -242,40 +242,38 @@ def custom_get(data, key, default):
 
 def construct_metadata(nodes_data):
     """
-    Construct the metadata dictionary using the data coming from the configured workspace
+    Construct the metadata dictionary using the data coming from the configured workspace.
+
     Parameters
     ----------
     nodes_data:
         dict containing the data configured in the workspace
+
     Returns
     -------
     metadata:
-        dict contaning the metadata that will be used in exporting the code or running a simulation
+        dict containing the metadata that will be used in exporting the code or running a simulation.
+        Uses schema-aligned keys: ``dynamics`` (not ``model``), ``network`` (not ``connectivity``).
     """
+    noise_val = custom_get(nodes_data, "noise", None)
     metadata = {
-        "model": {
-            "name": custom_get(nodes_data, "model", "Generic2dOscillator"),
-            "parameters": {},
-        },
-        "connectivity": {
+        "dynamics": custom_get(nodes_data, "model", "Generic2dOscillator"),
+        "coupling": custom_get(nodes_data, "coupling", "Linear"),
+        "network": {
             "parcellation": {
                 "atlas": {
                     "name": custom_get(nodes_data, "parcellation", "DesikanKilliany"),
                 }
             },
-            "tractogram": custom_get(nodes_data, "tractogram", "dTOR"),
-        },
-        "coupling": {
-            "name": custom_get(nodes_data, "coupling", "Linear"),
+            "tractogram": {
+                "name": custom_get(nodes_data, "tractogram", "dTOR"),
+            },
         },
         "integration": {
             "method": custom_get(nodes_data, "integrationMethod", "Heun"),
             "noise": (
-                {
-                    "additive": "additive"
-                    in custom_get(nodes_data, "noise", None).lower()
-                }
-                if custom_get(nodes_data, "noise", None)
+                {"additive": "additive" in noise_val.lower()}
+                if noise_val
                 else None
             ),
         },


### PR DESCRIPTION
## Summary

Fixes the 'list' object has no attribute 'update' errors reported in virtual-twin/tvbo#16 that occurred when using the JupyterLab extension to export code or run simulations.

## Root cause

`construct_metadata` was emitting legacy keys (`model`/`connectivity`) and passing model/coupling as dicts instead of plain name strings. The `configure_simulation_experiment` API in tvbo expects the current schema keys (`dynamics`/`network`) and plain strings it can resolve via `from_db()`.

Additionally, `tractogram` was passed as a bare string instead of a dict, causing `TypeError: Tractogram() argument after ** must be a mapping, not str`.

## Changes

- Emit `dynamics`/`network` keys instead of legacy `model`/`connectivity`
- Pass model and coupling as plain name strings so `configure_simulation_experiment` resolves them via `Dynamics.from_db()` / `Coupling.from_db()`
- Pass `tractogram` as `{"name": ...}` dict instead of a bare string

The companion fixes in tvbo (resolving dynamics/coupling via `from_db()`, default `conduction_speed`) are tracked in virtual-twin/tvbo#16.
